### PR TITLE
Add compatibility with Nuke 9.2

### DIFF
--- a/Source/AnimatedImage.swift
+++ b/Source/AnimatedImage.swift
@@ -7,7 +7,7 @@ import FLAnimatedImage
 import Nuke
 
 extension FLAnimatedImageView {
-    @objc open override func nuke_display(image: Image?) {
+    @objc open override func nuke_display(image: PlatformImage?) {
         guard image != nil else {
             self.animatedImage = nil
             self.image = nil


### PR DESCRIPTION
Deprecated alias was removed in Nuke 9.2: https://github.com/kean/Nuke/commit/4c2222822527300267794be4b8c91a06c530f927